### PR TITLE
Increase reqwest timeout duration

### DIFF
--- a/ch_02/tricoder/src/main.rs
+++ b/ch_02/tricoder/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     let target = args[1].as_str();
 
-    let http_timeout = Duration::from_secs(5);
+    let http_timeout = Duration::from_secs(30);
     let http_client = Client::builder()
         .redirect(redirect::Policy::limited(4))
         .timeout(http_timeout)


### PR DESCRIPTION
This webservice seems to be under fairly heavy pressure and a 5 second timeout will make this request fail most of the time. Because this request is only made once I don't see any harm in setting the timeout to 30 seconds.